### PR TITLE
Bump cfg-if to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["text-processing", "encoding", "web-programming", "internationaliz
 [dependencies]
 encoding_rs = "0.8.17"
 memchr = "2.2.0"
-cfg-if = "0.1.10"
+cfg-if = "1.0"
 rayon = { version = "1.3.0", optional = true }
 arrayvec = { version = "0.5.1", optional = true }
 


### PR DESCRIPTION
Allows deduplicating dependencies since quite other libraries already use 1.0. Maybe a minor or patch version bump will be good.