### PR TITLE
Added a way to detect the encoding among a given list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /target
 **/*.rs.bk
 Cargo.lock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3123,7 +3123,7 @@ impl EncodingDetector {
             }
         }
 
-        if filter.is_allowed(encoding) {
+        if !filter.is_allowed(encoding) {
             panic!("can't guess an encoding: the given encoding filter is blocking all encodings");
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ use core::arch::x86::_mm_movemask_epi8;
 use core::arch::x86_64::__m128i;
 #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
 use core::arch::x86_64::_mm_movemask_epi8;
-use core::panicking::panic;
 
 use encoding_rs::Decoder;
 use encoding_rs::DecoderResult;
@@ -49,7 +48,7 @@ mod tld;
 use data::*;
 use tld::classify_tld;
 use tld::Tld;
-use crate::EncodingFilterType::{Blacklist, Whitelist};
+use EncodingFilterType::{Blacklist, Whitelist};
 
 const LATIN_ADJACENCY_PENALTY: i64 = -50;
 
@@ -3026,6 +3025,11 @@ impl EncodingDetector {
         }
     }
 
+    /// Same as `guess_asses`, but only guesses among the encoding that the given `filter` allows.
+    ///
+    /// # Panics
+    ///
+    /// If `filter` doesn't allow any encoding.
     pub fn guess_among(&self, tld: Option<&[u8]>, filter: &EncodingFilter) -> (&'static Encoding, bool) {
         let mut tld_type = tld.map_or(Tld::Generic, |tld| {
             assert!(!contains_upper_case_period_or_non_ascii(tld));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ use core::arch::x86::_mm_movemask_epi8;
 use core::arch::x86_64::__m128i;
 #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
 use core::arch::x86_64::_mm_movemask_epi8;
+use core::panicking::panic;
 
 use encoding_rs::Decoder;
 use encoding_rs::DecoderResult;
@@ -48,6 +49,7 @@ mod tld;
 use data::*;
 use tld::classify_tld;
 use tld::Tld;
+use crate::EncodingFilterType::{Blacklist, Whitelist};
 
 const LATIN_ADJACENCY_PENALTY: i64 = -50;
 
@@ -2826,6 +2828,47 @@ impl BeforeNonAscii {
     }
 }
 
+enum EncodingFilterType {
+    Whitelist,
+    Blacklist,
+}
+
+pub struct EncodingFilter<'a> {
+    filter_type: EncodingFilterType,
+    encodings: &'a[&'a Encoding],
+}
+
+impl <'a> EncodingFilter<'a> {
+    pub fn allow_only(encodings: &'a[&'a Encoding]) -> Self {
+        Self {
+            filter_type: Whitelist,
+            encodings,
+        }
+    }
+
+    pub fn allow_all_except(encodings: &'a[&'a Encoding]) -> Self {
+        Self {
+            filter_type: Blacklist,
+            encodings,
+        }
+    }
+
+    pub fn allow_all() -> Self {
+        Self {
+            filter_type: Blacklist,
+            encodings: &[],
+        }
+    }
+
+    pub fn is_allowed(&self, encoding: &Encoding) -> bool {
+        let found = self.encodings.contains(&encoding);
+        match self.filter_type {
+            Whitelist => found,
+            Blacklist => !found,
+        }
+    }
+}
+
 /// A Web browser-oriented detector for guessing what character
 /// encoding a stream of bytes is encoded in.
 ///
@@ -2976,6 +3019,14 @@ impl EncodingDetector {
     /// one other candidate. If this method returns `false`, the
     /// guessed encoding is likely to be wrong.
     pub fn guess_assess(&self, tld: Option<&[u8]>, allow_utf8: bool) -> (&'static Encoding, bool) {
+        if allow_utf8 {
+            self.guess_among(tld, &EncodingFilter::allow_all())
+        } else {
+            self.guess_among(tld, &EncodingFilter::allow_all_except(&[UTF_8]))
+        }
+    }
+
+    pub fn guess_among(&self, tld: Option<&[u8]>, filter: &EncodingFilter) -> (&'static Encoding, bool) {
         let mut tld_type = tld.map_or(Tld::Generic, |tld| {
             assert!(!contains_upper_case_period_or_non_ascii(tld));
             classify_tld(tld)
@@ -2984,19 +3035,23 @@ impl EncodingDetector {
         if self.non_ascii_seen == 0
             && self.esc_seen
             && self.candidates[Self::ISO_2022_JP_INDEX].score.is_some()
+            && filter.is_allowed(&ISO_2022_JP)
         {
             return (ISO_2022_JP, true);
         }
 
         if self.candidates[Self::UTF_8_INDEX].score.is_some() {
-            if allow_utf8 {
+            if filter.is_allowed(&UTF_8) {
                 return (UTF_8, true);
             }
             // Various test cases that prohibit UTF-8 detection want to
             // see windows-1252 specifically. These tests run on generic
             // domains. However, if we returned windows-1252 on
             // some non-generic domains, we'd cause reloads.
-            return (self.candidates[encoding_for_tld(tld_type)].encoding(), true);
+            let encoding = self.candidates[encoding_for_tld(tld_type)].encoding();
+            if filter.is_allowed(&encoding) {
+                return (encoding, true);
+            }
         }
 
         let mut encoding = self.candidates[encoding_for_tld(tld_type)].encoding();
@@ -3041,6 +3096,9 @@ impl EncodingDetector {
             }
         }
         for (i, candidate) in self.candidates.iter().enumerate().skip(Self::FIRST_NORMAL) {
+            if !filter.is_allowed(&candidate.encoding()) {
+                continue;
+            }
             if let Some(score) = candidate.score(i, tld_type, expectation_is_valid) {
                 if score > max {
                     max = score;
@@ -3054,11 +3112,17 @@ impl EncodingDetector {
             if (visual_score > max || encoding == WINDOWS_1255)
                 && visual.plausible_punctuation()
                     > self.candidates[Self::LOGICAL_INDEX].plausible_punctuation()
+                && filter.is_allowed(&ISO_8859_8)
             {
                 // max = visual_score;
                 encoding = ISO_8859_8;
             }
         }
+
+        if filter.is_allowed(encoding) {
+            panic!("can't guess an encoding: the given encoding filter is blocking all encodings");
+        }
+
         (encoding, max >= 0)
     }
 


### PR DESCRIPTION
Added a way to detect the encoding among a restricted list of encodings using a filter:

```rust
det.guess_among(None, &EncodingFilter::allow_only(&[SHIFT_JIS, WINDOWS_1251, WINDOWS_1252]))
```

Use case example:  
It can be useful to decode a file that was generated by a software that outputs data in a restricted set of encodings.

The filter can also be used as a blacklist:

```rust
det.guess_among(None, &EncodingFilter::allow_all_except(&[SHIFT_JIS, WINDOWS_1251, WINDOWS_1252]))
```