### PR TITLE
Upgrade encoding_rs and add `alloc` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["encoding", "web", "unicode", "charset"]
 categories = ["text-processing", "encoding", "web-programming", "internationalization"]
 
 [dependencies]
-encoding_rs = { version = "0.8.29", default-features = false }
+encoding_rs = { version = "0.8.31", default-features = false, features = ["alloc"] }
 memchr = { version = "2.2.0", default-features = false }
 cfg-if = "1.0"
 rayon = { version = "1.3.0", optional = true }


### PR DESCRIPTION
Though it compiles now, #8 still presents when running test cases.