### PR TITLE
Work on making cargo test run again.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3230,12 +3230,15 @@ mod tests {
     use encoding_rs::WINDOWS_1258;
     use encoding_rs::WINDOWS_874;
 
+    extern crate std;
+    use std::string::String;
+    use std::vec::Vec;
+
     fn check_bytes(bytes: &[u8], encoding: &'static Encoding) {
         let mut det = EncodingDetector::new();
         det.feed(bytes, true);
         let enc = det.guess(None, false);
         let (decoded, _) = enc.decode_without_bom_handling(bytes);
-        println!("{:?}", decoded);
         assert_eq!(enc, encoding);
     }
 


### PR DESCRIPTION
Partial fix for https://github.com/hsivonen/chardetng/issues/11

Running `cargo test` produces this output

```
error[E0599]: no method named `decode_without_bom_handling` found for reference `&encoding_rs::Encoding` in the current scope
    --> src/lib.rs:3241:32
     |
3241 |         let (decoded, _) = enc.decode_without_bom_handling(bytes);
     |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: there is a method with a similar name: `new_decoder_without_bom_handling`

error[E0599]: no method named `encode` found for reference `&'static encoding_rs::Encoding` in the current scope
    --> src/lib.rs:3252:22
     |
3252 |             encoding.encode(&orthographic)
     |                      ^^^^^^ help: there is a method with a similar name: `new_encoder`

error[E0599]: no method named `encode` found for reference `&'static encoding_rs::Encoding` in the current scope
    --> src/lib.rs:3254:22
     |
3254 |             encoding.encode(input)
     |                      ^^^^^^ help: there is a method with a similar name: `new_encoder`

error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
    --> src/lib.rs:3247:14
     |
3247 |         let (bytes, _, _) = if encoding == WINDOWS_1258 {
     |              ^^^^^ doesn't have a size known at compile-time
     |
     = help: the trait `Sized` is not implemented for `[u8]`
     = note: all local variables must have a statically known size
     = help: unsized locals are gated as an unstable feature

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `chardetng` (lib test) due to 4 previous errors
```

This is because the test code needs the `alloc` feature included for encoding_rs for the tests to work.